### PR TITLE
add settings dialog with model configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,12 @@
       "dependencies": {
         "@auth/drizzle-adapter": "^1.1.0",
         "@radix-ui/react-avatar": "^1.1.0",
+        "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-dropdown-menu": "^2.1.1",
+        "@radix-ui/react-select": "^2.1.1",
+        "@radix-ui/react-separator": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.0",
+        "@radix-ui/react-toast": "^1.2.1",
         "@t3-oss/env-nextjs": "^0.10.1",
         "@tanstack/react-query": "^5.50.0",
         "@trpc/client": "^11.0.0-rc.446",
@@ -1366,6 +1370,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.0.tgz",
+      "integrity": "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
@@ -1473,6 +1483,42 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.1.tgz",
+      "integrity": "sha512-zysS+iU4YP3STKNS6USvFVqI4qqx8EpiwmT5TuCApVEBca+eRCbONi4EgzfNSuVnOXvC5UPHHMjs8RXO6DH9Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-focus-guards": "1.1.0",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -1780,6 +1826,72 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.1.1.tgz",
+      "integrity": "sha512-8iRDfyLtzxlprOo9IicnzvpsO1wNCkuwzzCM+Z5Rb5tNOpCdMvcc2AkzX0Fz+Tz9v6NJ5B/7EEgyZveo4FBRfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-collection": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-focus-guards": "1.1.0",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.0.tgz",
+      "integrity": "sha512-3uBAs+egzvJBDZAzvb/n4NxxOYpnspmWxO2u5NbZ8Y6FM/NdrGSF9bop3Cf6F6C71z1rTSn8KV0Fo2ZVd79lGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
@@ -1794,6 +1906,40 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.1.tgz",
+      "integrity": "sha512-5trl7piMXcZiCq7MW6r8YYmu0bK5qDpTWz+FdEPdKyft2UixkspheYbjbrLXVN5NGKHFbOP7lm8eD0biiSqZqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-collection": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -1864,6 +2010,21 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
+      "integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-rect": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
@@ -1896,6 +2057,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.0.tgz",
+      "integrity": "sha512-N8MDZqtgCgG5S3aV60INAB475osJousYpZ4cTJ2cFbMpdHS5Y6loLTH8LPtkj2QN0x93J30HT/M3qJXM0+lyeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,12 @@
   "dependencies": {
     "@auth/drizzle-adapter": "^1.1.0",
     "@radix-ui/react-avatar": "^1.1.0",
+    "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
+    "@radix-ui/react-select": "^2.1.1",
+    "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-toast": "^1.2.1",
     "@t3-oss/env-nextjs": "^0.10.1",
     "@tanstack/react-query": "^5.50.0",
     "@trpc/client": "^11.0.0-rc.446",

--- a/src/actions/chat-settings/chat-settings.ts
+++ b/src/actions/chat-settings/chat-settings.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { api } from "~/trpc/server";
+import { validateSettingsInput } from "./utils";
+import { type RouterInputs } from "~/trpc/react";
+
+export async function updateChatSettings(
+  settings: RouterInputs["openai"]["updateChatSettings"],
+) {
+  // ensure input isn't manually generated or malformed
+  const validatedSettings = await validateSettingsInput(settings);
+  await api.openai.updateChatSettings(validatedSettings);
+}

--- a/src/actions/chat-settings/index.ts
+++ b/src/actions/chat-settings/index.ts
@@ -1,0 +1,1 @@
+export { updateChatSettings } from "./chat-settings";

--- a/src/actions/chat-settings/utils.ts
+++ b/src/actions/chat-settings/utils.ts
@@ -1,0 +1,25 @@
+import { type RouterInputs } from "~/trpc/react";
+import { api } from "~/trpc/server";
+
+export async function validateSettingsInput(
+  input: unknown,
+): Promise<RouterInputs["openai"]["updateChatSettings"]> {
+  if (!isUpdateSettingsInput(input)) {
+    throw new Error("Malformed settings");
+  }
+
+  if (input.model) {
+    const supportedModels = await api.openai.getChatModels();
+    if (!supportedModels.some((model) => model.id === input.model)) {
+      throw new Error("Invalid model");
+    }
+  }
+
+  return input;
+}
+
+function isUpdateSettingsInput(
+  input: unknown,
+): input is RouterInputs["openai"]["updateChatSettings"] {
+  return typeof input === "object" && !!input && "model" in input;
+}

--- a/src/app/__components/avatar/avatar.tsx
+++ b/src/app/__components/avatar/avatar.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "~/lib/ui/dropdown-menu";
+import { SettingsMenuItem } from "./settings-menu-item";
 
 type Props = {
   imageUrl: string;
@@ -27,6 +28,7 @@ export function Avatar({ imageUrl, fallback }: Props) {
       </DropdownMenuTrigger>
 
       <DropdownMenuContent>
+        <SettingsMenuItem />
         <DropdownMenuItem>
           <Link href={"/api/auth/signout"}>Sign out</Link>
         </DropdownMenuItem>

--- a/src/app/__components/avatar/index.ts
+++ b/src/app/__components/avatar/index.ts
@@ -1,0 +1,1 @@
+export { Avatar } from "./avatar";

--- a/src/app/__components/avatar/settings-menu-item.tsx
+++ b/src/app/__components/avatar/settings-menu-item.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { DropdownMenuItem } from "~/lib/ui/dropdown-menu";
+import { createQueryString } from "~/lib/utils";
+
+export function SettingsMenuItem() {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  function handleClick() {
+    const pathWithParam = `${pathname}${createQueryString(searchParams, "settings", "true")}`;
+    router.push(pathWithParam);
+  }
+
+  return <DropdownMenuItem onClick={handleClick}>Settings</DropdownMenuItem>;
+}

--- a/src/app/__components/settings-dialog/chat-settings/chat-model.tsx
+++ b/src/app/__components/settings-dialog/chat-settings/chat-model.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { type Model } from "openai/resources/index.mjs";
+import { useOptimistic, useTransition } from "react";
+import { updateChatSettings } from "~/actions/chat-settings";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/lib/ui/select";
+import { Typography } from "~/lib/ui/typography";
+import { useToast } from "~/lib/ui/use-toast";
+
+type Props = {
+  modelId: string;
+  models: Model[];
+};
+
+export function ChatModel({ modelId, models }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const [selectedModel, setSelectedModel] = useOptimistic<string, string>(
+    modelId,
+    (_, newModelId) => newModelId,
+  );
+  const router = useRouter();
+  const { toast } = useToast();
+
+  function handleChange(newModelId: string) {
+    startTransition(async () => {
+      setSelectedModel(newModelId);
+      try {
+        await updateChatSettings({ model: newModelId });
+        router.refresh();
+        toast({ variant: "success", title: "Model updated" });
+      } catch (e) {
+        toast({ variant: "destructive", title: "Failed to update model" });
+        console.error(e);
+      }
+    });
+  }
+
+  return (
+    <div className="flex items-center justify-between">
+      <Typography variant="smallText">Model</Typography>
+      <Select
+        value={selectedModel}
+        disabled={isPending}
+        onValueChange={handleChange}
+      >
+        <SelectTrigger className="w-[180px]">
+          <SelectValue placeholder="Select model" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            {models.map((model) => (
+              <SelectItem key={model.id} value={model.id}>
+                {model.id}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/src/app/__components/settings-dialog/chat-settings/chat-settings.tsx
+++ b/src/app/__components/settings-dialog/chat-settings/chat-settings.tsx
@@ -1,0 +1,15 @@
+import { api } from "~/trpc/server";
+import { ChatModel } from "./chat-model";
+
+export async function ChatSettings() {
+  const [models, settings] = await Promise.all([
+    api.openai.getChatModels(),
+    api.openai.getChatSettings(),
+  ]);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <ChatModel modelId={settings.model} models={models} />
+    </div>
+  );
+}

--- a/src/app/__components/settings-dialog/chat-settings/index.ts
+++ b/src/app/__components/settings-dialog/chat-settings/index.ts
@@ -1,0 +1,1 @@
+export { ChatSettings } from "./chat-settings"

--- a/src/app/__components/settings-dialog/index.ts
+++ b/src/app/__components/settings-dialog/index.ts
@@ -1,0 +1,1 @@
+export { SettingsDialog } from "./settings-dialog"

--- a/src/app/__components/settings-dialog/settings-dialog-router.tsx
+++ b/src/app/__components/settings-dialog/settings-dialog-router.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "~/lib/ui/dialog";
+import { Separator } from "~/lib/ui/separator";
+import { removeQueryString } from "~/lib/utils";
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export function SettingsDialogRouter({ children }: Props) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  function handleClose() {
+    const withoutSettingsParam = `${pathname}${removeQueryString(searchParams, "settings")}`;
+    router.push(withoutSettingsParam);
+  }
+
+  return (
+    <Dialog open={!!searchParams.get("settings")} onOpenChange={handleClose}>
+      <DialogContent
+        className="gap-2 p-0 sm:max-w-[425px]"
+        aria-describedby={undefined}
+      >
+        <DialogHeader className="p-4">
+          <DialogTitle>Settings</DialogTitle>
+        </DialogHeader>
+
+        <Separator />
+
+        <div className="p-4">{children}</div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/__components/settings-dialog/settings-dialog.tsx
+++ b/src/app/__components/settings-dialog/settings-dialog.tsx
@@ -1,0 +1,10 @@
+import { ChatSettings } from "./chat-settings";
+import { SettingsDialogRouter } from "./settings-dialog-router";
+
+export function SettingsDialog() {
+  return (
+    <SettingsDialogRouter>
+      <ChatSettings />
+    </SettingsDialogRouter>
+  );
+}

--- a/src/app/chat/_components/message-board/message-alignment.tsx
+++ b/src/app/chat/_components/message-board/message-alignment.tsx
@@ -1,18 +1,19 @@
+import { ChatMessageType } from "~/server/api/routers/open-ai/types";
 import { type RouterOutputs } from "~/trpc/react";
 
 type Props = {
-  type: RouterOutputs["openai"]["getMessages"][number]["type"];
+  type: RouterOutputs["openai"]["getChatMessages"][number]["type"];
   children: React.ReactNode;
 };
 
 export function MessageAlignment({ type, children }: Props) {
   function messageAlignment(
-    messageType: RouterOutputs["openai"]["getMessages"][number]["type"],
+    messageType: RouterOutputs["openai"]["getChatMessages"][number]["type"],
   ): string {
     switch (messageType) {
-      case "user-sent":
+      case ChatMessageType.UserSent:
         return "justify-end";
-      case "llm-response":
+      case ChatMessageType.LLMResponse:
         return "justify-start";
       default:
         return "justify-start";

--- a/src/app/chat/_components/message-board/message-board.tsx
+++ b/src/app/chat/_components/message-board/message-board.tsx
@@ -8,11 +8,12 @@ import { type RouterOutputs } from "~/trpc/react";
 import { messageFromStreamingResponse } from "../utils";
 import { Message } from "./message";
 import { MessagePending } from "./message-pending";
+import { ChatMessageType } from "~/server/api/routers/open-ai/types";
 
 // TODO: container overflow causes very slight misalignment of content due to the scrollbar. Would be nice to detect and adjust for this
 
 type Props = {
-  messages: RouterOutputs["openai"]["getMessages"];
+  messages: RouterOutputs["openai"]["getChatMessages"];
   streamingResponse: string;
   responsePending: boolean;
 };
@@ -65,7 +66,9 @@ function MessageBoardComponent({
             <Message key={message.id} message={message} />
           ))}
 
-          {responsePending && <MessagePending type="llm-response" />}
+          {responsePending && (
+            <MessagePending type={ChatMessageType.LLMResponse} />
+          )}
 
           {streamingResponse && (
             <Message

--- a/src/app/chat/_components/message-board/message-bubble.tsx
+++ b/src/app/chat/_components/message-board/message-bubble.tsx
@@ -1,20 +1,21 @@
 import { TriangleAlert } from "lucide-react";
+import { ChatMessageType } from "~/server/api/routers/open-ai/types";
 import { type RouterOutputs } from "~/trpc/react";
 
 type Props = {
-  type?: RouterOutputs["openai"]["getMessages"][number]["type"];
+  type?: RouterOutputs["openai"]["getChatMessages"][number]["type"];
   error?: boolean;
   children: React.ReactNode;
 };
 
 export function MessageBubble({ type, error, children }: Props) {
   function messageColorByType(
-    messageType?: RouterOutputs["openai"]["getMessages"][number]["type"],
+    messageType?: RouterOutputs["openai"]["getChatMessages"][number]["type"],
   ): string {
     switch (messageType) {
-      case "user-sent":
+      case ChatMessageType.UserSent:
         return "bg-blue-700 text-white";
-      case "llm-response":
+      case ChatMessageType.LLMResponse:
         return "bg-slate-100 text-black";
       default:
         return "bg-gray-500";

--- a/src/app/chat/_components/message-board/message-pending.tsx
+++ b/src/app/chat/_components/message-board/message-pending.tsx
@@ -2,7 +2,7 @@ import { type RouterOutputs } from "~/trpc/react";
 import { MessageAlignment } from "./message-alignment";
 
 type Props = {
-  type: RouterOutputs["openai"]["getMessages"][number]["type"];
+  type: RouterOutputs["openai"]["getChatMessages"][number]["type"];
 };
 
 export function MessagePending({ type }: Props) {

--- a/src/app/chat/_components/message-board/message.tsx
+++ b/src/app/chat/_components/message-board/message.tsx
@@ -2,15 +2,19 @@ import { type RouterOutputs } from "~/trpc/react";
 import { MessageAlignment } from "./message-alignment";
 import { memo } from "react";
 import { MessageBubble } from "./message-bubble";
+import { ChatMessageStatus } from "~/server/api/routers/open-ai/types";
 
 type Props = {
-  message: RouterOutputs["openai"]["getMessages"][number];
+  message: RouterOutputs["openai"]["getChatMessages"][number];
 };
 
 function MessageComponent({ message }: Props) {
   return (
     <MessageAlignment type={message.type}>
-      <MessageBubble type={message.type} error={message.status === "failed"}>
+      <MessageBubble
+        type={message.type}
+        error={message.status === ChatMessageStatus.Failed}
+      >
         {message.message}
       </MessageBubble>
     </MessageAlignment>

--- a/src/app/chat/_components/utils.ts
+++ b/src/app/chat/_components/utils.ts
@@ -1,18 +1,22 @@
+import {
+  ChatMessageStatus,
+  ChatMessageType,
+} from "~/server/api/routers/open-ai/types";
 import type { RouterOutputs, api } from "~/trpc/react";
 
 export function createOptimisticReponse(
   trpcUtils: ReturnType<(typeof api)["useUtils"]>,
   message: string,
 ) {
-  const previousMessages = trpcUtils.openai.getMessages.getData();
-  trpcUtils.openai.getMessages.setData(undefined, () => [
+  const previousMessages = trpcUtils.openai.getChatMessages.getData();
+  trpcUtils.openai.getChatMessages.setData(undefined, () => [
     ...(previousMessages ?? []),
     {
       id: "optimistic-" + Math.random(),
       userId: "optimistic",
       message,
-      type: "user-sent",
-      status: "success",
+      type: ChatMessageType.UserSent,
+      status: ChatMessageStatus.Success,
       createdAt: new Date(),
     },
   ]);
@@ -22,11 +26,11 @@ export function createOptimisticReponse(
 
 export function messageFromStreamingResponse(
   streamingResponse: string,
-): RouterOutputs["openai"]["getMessages"][number] {
+): RouterOutputs["openai"]["getChatMessages"][number] {
   return {
     id: "streaming-response",
-    type: "llm-response",
-    status: "success",
+    type: ChatMessageType.LLMResponse,
+    status: ChatMessageStatus.Success,
     message: streamingResponse,
   };
 }

--- a/src/app/chat/_hooks/open-ai.ts
+++ b/src/app/chat/_hooks/open-ai.ts
@@ -16,16 +16,17 @@ export function useOpenAIChatMutation() {
     },
     onError: () => {
       setIsPendingResponse(false);
-      void utils.openai.getMessages.invalidate();
+      void utils.openai.getChatMessages.invalidate();
     },
     onSuccess: async (responseChunks) => {
       setIsProcessingResponse(true);
+
       for await (const chunk of responseChunks) {
         setIsPendingResponse(false);
         setStreamingResponse((cur) => cur + chunk);
       }
 
-      await utils.openai.getMessages.invalidate();
+      await utils.openai.getChatMessages.invalidate();
       setIsProcessingResponse(false);
       setStreamingResponse("");
     },

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -6,7 +6,7 @@ import { api } from "~/trpc/react";
 import { useOpenAIChatMutation } from "./_hooks/open-ai";
 
 export default function Chat() {
-  const { data: messages } = api.openai.getMessages.useQuery();
+  const { data: messages } = api.openai.getChatMessages.useQuery();
   const {
     sendMessage,
     streamingResponse,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,8 @@ import { type Metadata } from "next";
 import { TRPCReactProvider } from "~/trpc/react";
 import { TopNav } from "./__components/top-nav";
 import { ThemeProvider } from "~/lib/ui/theme-provider";
+import { SettingsDialog } from "./__components/settings-dialog/settings-dialog";
+import { Toaster } from "~/lib/ui/toaster";
 
 const fontSans = FontSans({
   subsets: ["latin"],
@@ -38,6 +40,8 @@ export default function RootLayout({
               <TopNav />
               {children}
             </main>
+            <SettingsDialog />
+            <Toaster />
           </ThemeProvider>
         </TRPCReactProvider>
       </body>

--- a/src/lib/ui/dialog.tsx
+++ b/src/lib/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "~/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/src/lib/ui/dropdown-menu.tsx
+++ b/src/lib/ui/dropdown-menu.tsx
@@ -83,7 +83,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className
     )}
@@ -99,7 +99,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}

--- a/src/lib/ui/select.tsx
+++ b/src/lib/ui/select.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className,
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className,
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className,
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+};

--- a/src/lib/ui/separator.tsx
+++ b/src/lib/ui/separator.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "~/lib/utils"
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }

--- a/src/lib/ui/toast.tsx
+++ b/src/lib/ui/toast.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import * as React from "react"
+import * as ToastPrimitives from "@radix-ui/react-toast"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import { cn } from "~/lib/utils"
+
+const ToastProvider = ToastPrimitives.Provider
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      className
+    )}
+    {...props}
+  />
+))
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName
+
+const toastVariants = cva(
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  {
+    variants: {
+      variant: {
+        default: "border bg-background text-foreground",
+        destructive:
+          "destructive group border-destructive bg-destructive text-destructive-foreground",
+          success: "success group border-green-600 bg-green-600 text-neutral-50",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
+    VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => {
+  return (
+    <ToastPrimitives.Root
+      ref={ref}
+      className={cn(toastVariants({ variant }), className)}
+      {...props}
+    />
+  )
+})
+Toast.displayName = ToastPrimitives.Root.displayName
+
+const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      className
+    )}
+    {...props}
+  />
+))
+ToastAction.displayName = ToastPrimitives.Action.displayName
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      className
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+))
+ToastClose.displayName = ToastPrimitives.Close.displayName
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn("text-sm font-semibold", className)}
+    {...props}
+  />
+))
+ToastTitle.displayName = ToastPrimitives.Title.displayName
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn("text-sm opacity-90", className)}
+    {...props}
+  />
+))
+ToastDescription.displayName = ToastPrimitives.Description.displayName
+
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>
+
+type ToastActionElement = React.ReactElement<typeof ToastAction>
+
+export {
+  type ToastProps,
+  type ToastActionElement,
+  ToastProvider,
+  ToastViewport,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+  ToastAction,
+}

--- a/src/lib/ui/toaster.tsx
+++ b/src/lib/ui/toaster.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "~/lib/ui/toast"
+import { useToast } from "~/lib/ui/use-toast"
+
+export function Toaster() {
+  const { toasts } = useToast()
+
+  return (
+    <ToastProvider>
+      {toasts.map(function ({ id, title, description, action, ...props }) {
+        return (
+          <Toast key={id} {...props}>
+            <div className="grid gap-1">
+              {title && <ToastTitle>{title}</ToastTitle>}
+              {description && (
+                <ToastDescription>{description}</ToastDescription>
+              )}
+            </div>
+            {action}
+            <ToastClose />
+          </Toast>
+        )
+      })}
+      <ToastViewport />
+    </ToastProvider>
+  )
+}

--- a/src/lib/ui/use-toast.ts
+++ b/src/lib/ui/use-toast.ts
@@ -1,0 +1,194 @@
+"use client"
+
+// Inspired by react-hot-toast library
+import * as React from "react"
+
+import type {
+  ToastActionElement,
+  ToastProps,
+} from "~/lib/ui/toast"
+
+const TOAST_LIMIT = 1
+const TOAST_REMOVE_DELAY = 1000000
+
+type ToasterToast = ToastProps & {
+  id: string
+  title?: React.ReactNode
+  description?: React.ReactNode
+  action?: ToastActionElement
+}
+
+const actionTypes = {
+  ADD_TOAST: "ADD_TOAST",
+  UPDATE_TOAST: "UPDATE_TOAST",
+  DISMISS_TOAST: "DISMISS_TOAST",
+  REMOVE_TOAST: "REMOVE_TOAST",
+} as const
+
+let count = 0
+
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER
+  return count.toString()
+}
+
+type ActionType = typeof actionTypes
+
+type Action =
+  | {
+      type: ActionType["ADD_TOAST"]
+      toast: ToasterToast
+    }
+  | {
+      type: ActionType["UPDATE_TOAST"]
+      toast: Partial<ToasterToast>
+    }
+  | {
+      type: ActionType["DISMISS_TOAST"]
+      toastId?: ToasterToast["id"]
+    }
+  | {
+      type: ActionType["REMOVE_TOAST"]
+      toastId?: ToasterToast["id"]
+    }
+
+interface State {
+  toasts: ToasterToast[]
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId)
+    dispatch({
+      type: "REMOVE_TOAST",
+      toastId: toastId,
+    })
+  }, TOAST_REMOVE_DELAY)
+
+  toastTimeouts.set(toastId, timeout)
+}
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case "ADD_TOAST":
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      }
+
+    case "UPDATE_TOAST":
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === action.toast.id ? { ...t, ...action.toast } : t
+        ),
+      }
+
+    case "DISMISS_TOAST": {
+      const { toastId } = action
+
+      // ! Side effects ! - This could be extracted into a dismissToast() action,
+      // but I'll keep it here for simplicity
+      if (toastId) {
+        addToRemoveQueue(toastId)
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id)
+        })
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === toastId || toastId === undefined
+            ? {
+                ...t,
+                open: false,
+              }
+            : t
+        ),
+      }
+    }
+    case "REMOVE_TOAST":
+      if (action.toastId === undefined) {
+        return {
+          ...state,
+          toasts: [],
+        }
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+      }
+  }
+}
+
+const listeners: Array<(state: State) => void> = []
+
+let memoryState: State = { toasts: [] }
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action)
+  listeners.forEach((listener) => {
+    listener(memoryState)
+  })
+}
+
+type Toast = Omit<ToasterToast, "id">
+
+function toast({ ...props }: Toast) {
+  const id = genId()
+
+  const update = (props: ToasterToast) =>
+    dispatch({
+      type: "UPDATE_TOAST",
+      toast: { ...props, id },
+    })
+  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id })
+
+  dispatch({
+    type: "ADD_TOAST",
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open) => {
+        if (!open) dismiss()
+      },
+    },
+  })
+
+  return {
+    id: id,
+    dismiss,
+    update,
+  }
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState)
+
+  React.useEffect(() => {
+    listeners.push(setState)
+    return () => {
+      const index = listeners.indexOf(setState)
+      if (index > -1) {
+        listeners.splice(index, 1)
+      }
+    }
+  }, [state])
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+  }
+}
+
+export { useToast, toast }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,25 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
+}
+
+export function createQueryString(
+  searchParams: URLSearchParams,
+  name: string,
+  value: string,
+) {
+  const params = new URLSearchParams(searchParams.toString());
+  params.set(name, value);
+
+  return `?${params.toString()}`;
+}
+
+export function removeQueryString(searchParams: URLSearchParams, name: string) {
+  const params = new URLSearchParams(searchParams.toString());
+  params.delete(name);
+  const newParams = params.toString();
+
+  return newParams ? `?${params.toString()}` : "";
 }

--- a/src/server/api/routers/open-ai/types.ts
+++ b/src/server/api/routers/open-ai/types.ts
@@ -1,5 +1,11 @@
-export type ChatMessageType = "user-sent" | "llm-response";
-export type ChatMessageStatus = "success" | "failed";
+export enum ChatMessageType {
+  UserSent = "user-sent",
+  LLMResponse = "llm-response",
+}
+export enum ChatMessageStatus {
+  Success = "success",
+  Failed = "failed",
+}
 
 export type ChatMessage = {
   id: string;

--- a/src/server/api/routers/open-ai/utils.ts
+++ b/src/server/api/routers/open-ai/utils.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_CHAT_MODEL = "gpt-3.5-turbo";

--- a/src/server/api/types.ts
+++ b/src/server/api/types.ts
@@ -1,0 +1,10 @@
+import { type Session } from "next-auth";
+import type OpenAI from "openai";
+import { type db } from "../db";
+
+export type ProtectedCtx = {
+  session: Session;
+  headers: Headers;
+  db: typeof db;
+  openai: OpenAI;
+};

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -34,6 +34,9 @@ export const users = createTable("user", {
 
 export const usersRelations = relations(users, ({ many }) => ({
   accounts: many(accounts),
+  sessions: many(sessions),
+  messages: many(messages),
+  chatSettings: many(chatSettings),
 }));
 
 export const accounts = createTable(
@@ -125,3 +128,23 @@ export const messages = createTable("message", {
     .notNull()
     .default(sql`CURRENT_TIMESTAMP`),
 });
+
+export const messagesRelations = relations(messages, ({ one }) => ({
+  user: one(users, { fields: [messages.userId], references: [users.id] }),
+}));
+
+export const chatSettings = createTable("chat_settings", {
+  id: varchar("id", { length: 255 })
+    .notNull()
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  userId: varchar("user_id", { length: 255 })
+    .notNull()
+    .unique()
+    .references(() => users.id),
+  model: varchar("model", { length: 255 }).notNull(),
+});
+
+export const chatSettingsRelations = relations(chatSettings, ({ one }) => ({
+  user: one(users, { fields: [chatSettings.userId], references: [users.id] }),
+}));


### PR DESCRIPTION
### Add settings dialog and setting to manage OpenAI model
- Add new table to manage chat based settings
- Add settings dialog with ability to change models (limited to models with `owned_by=openai`)
- Add optimistic updating for model change
- Add toast for success and fail paths of model change


![chrome_hVlKnVs4Vv](https://github.com/user-attachments/assets/048736ca-e9d5-43b2-b92b-94a563dfaf28)
